### PR TITLE
Change LX init environ to `container=lxc-smartos`

### DIFF
--- a/usr/src/lib/brand/lx/lx_init/lxinit.c
+++ b/usr/src/lib/brand/lx/lx_init/lxinit.c
@@ -968,7 +968,7 @@ static void
 lxi_init_exec(char **argv)
 {
 	const char *cmd = "/sbin/init";
-	char *const envp[] = { "container=zone", NULL };
+	char *const envp[] = { "container=lxc-smartos", NULL };
 	int e;
 
 	argv[0] = "init";


### PR DESCRIPTION
## Summary
[virt-what](https://people.redhat.com/~rjones/virt-what/) is a script to identify what type of virtualization is in use.

Running `virt-what` 1.20 on an LX zone outputs `lxc` — not exactly true, but close enough for our purposes.

However, running `virt-what` 1.21+ on an LX zone outputs nothing (i.e. bare-metal) — very wrong. ❌
## What changed in `virt-what`
```console
$ grep -A5 LXC virt-what-1.2*/virt-what.in
virt-what-1.20/virt-what.in:# Check for LXC containers
virt-what-1.20/virt-what.in-# http://www.freedesktop.org/wiki/Software/systemd/ContainerInterface
virt-what-1.20/virt-what.in-# Added by Marc Fournier
virt-what-1.20/virt-what.in-
virt-what-1.20/virt-what.in-if [ -e "${root}/proc/1/environ" ] &&
virt-what-1.20/virt-what.in-    cat "${root}/proc/1/environ" | tr '\000' '\n' | grep -Eiq '^container='; then
--
virt-what-1.21/virt-what.in:# Check for LXC containers
virt-what-1.21/virt-what.in-# http://www.freedesktop.org/wiki/Software/systemd/ContainerInterface
virt-what-1.21/virt-what.in-# Added by Marc Fournier
virt-what-1.21/virt-what.in-
virt-what-1.21/virt-what.in-if [ -e "${root}/proc/1/environ" ] &&
virt-what-1.21/virt-what.in-    cat "${root}/proc/1/environ" | tr '\000' '\n' | grep -Eiq '^container=lxc'; then
```

That is, previously, if PID 1's environment contained a variable named `container`, it would identify the system as LXC.  This test matches SmartOS LX zones since [`lxinit.c` sets `container=zone`](https://github.com/TritonDataCenter/illumos-joyent/blob/3ffb27d2b2e9a98f4b65dc527b83b2c3406b680c/usr/src/lib/brand/lx/lx_init/lxinit.c#L971).

But now it ***also*** checks that the value begins with `lxc`, so SmartOS LX zones no longer match.
## Background
We use Puppet to manage our LX zones, and Puppet's [Facter component calls `virt-what`](https://github.com/puppetlabs/facter/blob/034fbc0e50e10287b1ed3a1e1d5f1ed5f63d65a4/lib/facter/resolvers/virt_what.rb) to determine which rules to apply to the zones.  A few days ago, CentOS Stream 8 [updated `virt-what` to perform the `container=lxc` check](https://git.centos.org/rpms/virt-what/c/cc91b25ef6444bc5bdab7733203758bddb0d4d6d).  Puppet tries to apply bare-metal configuration to non-bare-metal systems, which wreaks havoc.

## Fix
I propose changing SmartOS LX environment variable `container=zone` to `container=lxc-smartos`.

- This addresses the above `virt-what` (and thus Puppet Facter) regression
   - I also submitted https://github.com/puppetlabs/facter/pull/2492, to have Puppet Facter avoid using `virt-what`, but I still think it would be helpful is `virt-what` returned a better result
- `systemd-detect-virt` still returns the same `container-other` value (this was the reason SmartOS LX added the `container=zone` environment variable in the first place — [1](https://smartos.org/bugview/OS-4259), [2](https://github.com/TritonDataCenter/illumos-joyent/commit/734281d35e64e35c0f0e0f42a791cf48604c2bbe))

## Test
### ✅ virt-what-1.20 + SmartOS 20220421T000508Z
```console
# virt-what
lxc
# facter virtual
lxc
# systemd-detect-virt
container-other
```
### ❌ virt-what-1.21 + SmartOS 20220421T000508Z
```console
# virt-what
(no output)
# facter virtual
physical
# systemd-detect-virt
container-other
```
### ✅ virt-what-1.21 + local build with this MR
```console
# virt-what
lxc
# facter virtual
lxc
# systemd-detect-virt
container-other
```
