### PR TITLE
OS-8433 Welcome 2023

### DIFF
--- a/usr/src/Makefile.master
+++ b/usr/src/Makefile.master
@@ -1126,7 +1126,7 @@ UTS_LABEL=	$(RELEASE)
 # format.
 #
 BOOTBANNER1=	SmartOS Version ^v ^w-bit
-# XXX SmartOS:  BANNER_YEAR pulled from illumos.sh
+# XXX SmartOS: BANNER_YEAR in environment set in smartos-live's build_illumos.
 BOOTBANNER2=	Copyright 2022-$(BANNER_YEAR) MNX Cloud, Inc.
 BOOTBANNER3=
 BOOTBANNER4=

--- a/usr/src/Makefile.master
+++ b/usr/src/Makefile.master
@@ -32,6 +32,7 @@
 # Copyright 2019 RackTop Systems.
 # Copyright 2020 Oxide Computer Company
 # Copyright 2020 Peter Tribble
+# Copyright 2023 MNX Cloud, Inc.
 #
 
 #
@@ -1124,8 +1125,9 @@ UTS_LABEL=	$(RELEASE)
 # bootbanner_expand_template() for more details about the template string
 # format.
 #
-BOOTBANNER1=	^o Version ^v ^w-bit
-BOOTBANNER2=
+BOOTBANNER1=	SmartOS Version ^v ^w-bit
+# XXX SmartOS:  BANNER_YEAR pulled from illumos.sh
+BOOTBANNER2=	Copyright 2022-$(BANNER_YEAR) MNX Cloud, Inc.
 BOOTBANNER3=
 BOOTBANNER4=
 BOOTBANNER5=

--- a/usr/src/uts/common/os/logsubr.c
+++ b/usr/src/uts/common/os/logsubr.c
@@ -24,7 +24,7 @@
  * Copyright (c) 2013 Gary Mills
  * Copyright (c) 1998, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright 2022 Joyent, Inc.
- * Copyright 2022 MNX Cloud, Inc.
+ * Copyright 2023 MNX Cloud, Inc.
  */
 
 #include <sys/types.h>
@@ -262,11 +262,8 @@ log_init(void)
 #ifdef	LEGACY_BANNER
 	printf("\rSunOS Release %s Version %s %u-bit\n",
 	    utsname.release, utsname.version, NBBY * (uint_t)sizeof (void *));
-	/*
-	 * Note: In the future this should be 2022-20XX, and delete this
-	 * comment when we don't need it anymore
-	 */
-	printf("Copyright 2022 MNX Cloud, Inc.\n");
+	/* NOTE: We might switch to BOOTBANNER after this. */
+	printf("Copyright 2022-2023 MNX Cloud, Inc.\n");
 #else
 	bootbanner_print(log_bootbanner_print, KM_SLEEP);
 #endif


### PR DESCRIPTION
In conjunction with TritonDataCenter/smartos-live#1069 which sets BANNER_YEAR, we now issue a two-line boot banner:

```
SmartOS Version joyent_20230109T215257Z 64-bit
Copyright 2022-2023 MNX Cloud, Inc.
```
This uses features from https://www.illumos.org/issues/12517