### PR TITLE
OS-8484 Headnode NTP config should be able to support RAN networks

### DIFF
--- a/usr/src/cmd/svc/milestone/smartdc-config
+++ b/usr/src/cmd/svc/milestone/smartdc-config
@@ -20,6 +20,7 @@
 # CDDL HEADER END
 #
 # Copyright 2019 Joyent, Inc.
+# Copyright 2023 MNX Cloud, Inc.
 #
 
 #
@@ -141,6 +142,15 @@ case "$1" in
             if [[ "${CONFIG_admin_network}" != "..." ]]; then
                 ntp_aflag="-a ${CONFIG_admin_network}/${CONFIG_admin_netmask}"
             fi
+        fi
+        #
+        # Add any additional networks that should be permitted to use this
+        # host as a time server. This is most often used by RAN networks.
+        #
+        if [[ -n ${CONFIG_ntp_allow_networks} ]]; then
+            for i in ${CONFIG_ntp_allow_networks//,/ }; do
+                ntp_aflag="${ntp_aflag} -a $i"
+            done
         fi
 
         #


### PR DESCRIPTION
Companion: TritonDataCenter/smartos-live#1077

Change-Id: I2c8a81e269dd0c2dd2969669185309bd1c52907f