### PR TITLE
14744 Add TCP_INFO socket option

### DIFF
--- a/usr/src/man/man3c/qsort.3c
+++ b/usr/src/man/man3c/qsort.3c
@@ -19,7 +19,7 @@
 .\" Copyright (c) 2002, Sun Microsystems, Inc.  All Rights Reserved
 .\" Copyright 2020 Oxide Computer Company
 .\"
-.Dd October 11, 2020
+.Dd November 15, 2023
 .Dt QSORT 3C
 .Os
 .Sh NAME
@@ -52,7 +52,7 @@ The contents of the table are sorted in ascending order according to the
 user-supplied comparison function.
 .Pp
 The
-.Fa Ibase
+.Fa base
 argument points to the element at the base of the table.
 The
 .Fa nel
@@ -62,6 +62,7 @@ The
 argument specifies the size of each element in bytes.
 The
 .Fa compar
+argument is the name of the comparison function, which is called with two
 arguments that point to the elements being compared.
 The comparison function need not compare every byte, so arbitrary data may be
 contained in the elements in addition to the values being compared.
@@ -94,7 +95,7 @@ The
 .Fn qsort
 and
 .Fn qsort_r
-function safely allows concurrent access by multiple threads
+functions safely allow concurrent access by multiple threads
 to disjoint data, such as overlapping subtrees or tables.
 .Sh EXAMPLES
 .Sy Example 1

--- a/usr/src/man/man3head/tcp.h.3head
+++ b/usr/src/man/man3head/tcp.h.3head
@@ -68,9 +68,22 @@ Avoid coalescing of small segments.
 
 .sp
 .LP
+\fB\fBTCP_INFO\fR\fR
+.ad
+.RS 15n
+Information about a socket's underlying TCP session may be retrieved by passing the read-only option
+TCP_INFO to getsockopt(2). It accepts a single argu ment: a pointer to an instance of struct tcp_info.
+.RE
+
+.sp
+.LP
 The macro is defined in the header. The implementation need not allow the value
 of the option to be set with \fBsetsockopt()\fR or retrieved with
 \fBgetsockopt()\fR.
+.sp
+.LP
+
+
 .SH ATTRIBUTES
 .sp
 .LP

--- a/usr/src/uts/common/brand/lx/sys/lx_socket.h
+++ b/usr/src/uts/common/brand/lx/sys/lx_socket.h
@@ -437,6 +437,22 @@ typedef struct lx_sockaddr_in6 {
 	/* one 32-bit field shorter than illumos */
 } lx_sockaddr_in6_t;
 
+enum {
+    LX_TCP_ESTABLISHED = 1,
+    LX_TCP_SYN_SENT,
+    LX_TCP_SYN_RECV,
+    LX_TCP_FIN_WAIT1,
+    LX_TCP_FIN_WAIT2,
+    LX_TCP_TIME_WAIT,
+    LX_TCP_CLOSE,
+    LX_TCP_CLOSE_WAIT,
+    LX_TCP_LAST_ACK,
+    LX_TCP_LISTEN,
+    LX_TCP_CLOSING,
+    LX_TCP_NEW_SYN_RECV,
+    LX_TCP_MAX_STATES
+};
+
 #ifdef	__cplusplus
 }
 #endif

--- a/usr/src/uts/common/brand/lx/syscall/lx_socket.c
+++ b/usr/src/uts/common/brand/lx/syscall/lx_socket.c
@@ -24,6 +24,7 @@
  * Use is subject to license terms.
  * Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
  * Copyright 2022 Joyent, Inc.
+ * Copyright 2023 Carlos Neira <cneirabustos@gmail.com>
  */
 
 #include <sys/errno.h>
@@ -2825,7 +2826,7 @@ static const lx_sockopt_map_t ltos_tcp_sockopts[LX_TCP_NOTSENT_LOWAT + 1] = {
 	{ TCP_LINGER2, sizeof (int) },		/* TCP_LINGER2		*/
 	{ OPTNOTSUP, 0 },			/* TCP_DEFER_ACCEPT - in code */
 	{ OPTNOTSUP, 0 },			/* TCP_WINDOW_CLAMP - in code */
-	{ OPTNOTSUP, 0 },			/* TCP_INFO		*/
+	{ TCP_INFO, sizeof (tcp_info_t) },	/* TCP_INFO		*/
 	{ TCP_QUICKACK, sizeof (int) },		/* TCP_QUICKACK		*/
 	{ TCP_CONGESTION, CC_ALGO_NAME_MAX },	/* TCP_CONGESTION	*/
 	{ OPTNOTSUP, 0 },			/* TCP_MD5SIG		*/
@@ -3865,6 +3866,49 @@ lx_getsockopt_tcp(sonode_t *so, int optname, void *optval, socklen_t *optlen)
 	lx_proto_opts_t sockopts_tbl = PROTO_SOCKOPTS(ltos_tcp_sockopts);
 
 	switch (optname) {
+
+	case LX_TCP_INFO:
+		error = socket_getsockopt(so, IPPROTO_TCP, optname, optval, optlen, 0,
+		    cr);
+		if (error != 0)
+		    goto out;
+
+		tcp_info_t *tcpi = (tcp_info_t*) optval;
+		switch(tcpi->tcpi_state)
+		{
+			case TCPS_ESTABLISHED:
+				tcpi->tcpi_state = LX_TCP_ESTABLISHED;
+				break;
+
+			case TCPS_CLOSING:
+				tcpi->tcpi_state = LX_TCP_CLOSE;
+
+				break;
+			case TCPS_LAST_ACK:
+				tcpi->tcpi_state = LX_TCP_LAST_ACK;
+				break;
+
+			case TCPS_CLOSE_WAIT:
+				tcpi->tcpi_state = LX_TCP_CLOSE_WAIT;
+				break;
+
+			case TCPS_FIN_WAIT_1:
+				tcpi->tcpi_state = LX_TCP_FIN_WAIT1;
+				break;
+
+			case TCPS_FIN_WAIT_2:
+				tcpi->tcpi_state = LX_TCP_FIN_WAIT2;
+				break;
+
+			case TCPS_TIME_WAIT:
+				tcpi->tcpi_state = LX_TCP_TIME_WAIT;
+				break;
+
+			default :
+				tcpi->tcpi_state = LX_TCP_ESTABLISHED;
+		}
+		return (error);
+
 	case LX_TCP_WINDOW_CLAMP:
 		/*
 		 * We do not support these options but some apps rely on them.

--- a/usr/src/uts/common/netinet/tcp.h
+++ b/usr/src/uts/common/netinet/tcp.h
@@ -23,6 +23,7 @@
  * Copyright (c) 1991, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2011 Nexenta Systems, Inc. All rights reserved.
  * Copyright 2022 Oxide Computer Company
+ * Copyright 2023 Carlos Neira <cneirabustos@gmail.com>
  */
 
 /*
@@ -75,6 +76,9 @@ struct tcphdr {
 	uint16_t	th_urp;		/* urgent pointer */
 };
 
+
+
+
 #define	TCPOPT_EOL	0
 #define	TCPOPT_NOP	1
 #define	TCPOPT_MAXSEG	2
@@ -88,6 +92,8 @@ struct tcphdr {
  * With an IP MTU of 576, this is 536.
  */
 #define	TCP_MSS	536
+
+
 
 /*
  * Options for use with [gs]etsockopt at the TCP level.
@@ -109,6 +115,44 @@ struct tcphdr {
 #define	TCP_KEEPALIVE	0x8	/* set keepalive timer */
 #endif
 
+#ifndef TCP_INFO
+#define	TCP_INFO	0x09	/* retrieve tcp_info structure */
+#endif
+	typedef struct tcp_info {
+		uint8_t	tcpi_state;
+		uint8_t	tcpi_ca_state;
+		uint8_t	tcpi_retransmits;
+		uint8_t	tcpi_probes;
+		uint8_t	tcpi_backoff;
+		uint8_t	tcpi_options;
+		uint8_t	tcpi_snd_wscale : 4, tcpi_rcv_wscale : 4;
+		uint32_t	tcpi_rto;
+		uint32_t	tcpi_ato;
+		uint32_t	tcpi_snd_mss;
+		uint32_t	tcpi_rcv_mss;
+		uint32_t	tcpi_unacked;
+		uint32_t	tcpi_sacked;
+		uint32_t	tcpi_lost;
+		uint32_t	tcpi_retrans;
+		uint32_t	tcpi_fackets;
+		/* Times. */
+		uint32_t	tcpi_last_data_sent;
+		uint32_t	tcpi_last_ack_sent;
+		uint32_t	tcpi_last_data_recv;
+		uint32_t	tcpi_last_ack_recv;
+		/* Metrics. */
+		uint32_t	tcpi_pmtu;
+		uint32_t	tcpi_rcv_ssthresh;
+		uint32_t	tcpi_rtt;
+		uint32_t	tcpi_rttvar;
+		uint32_t	tcpi_snd_ssthresh;
+		uint32_t	tcpi_snd_cwnd;
+		uint32_t	tcpi_advmss;
+		uint32_t	tcpi_reordering;
+		uint32_t	tcpi_rcv_rtt;
+		uint32_t	tcpi_rcv_space;
+		uint32_t	tcpi_total_retrans;
+	} tcp_info_t;
 
 #define	TCP_NOTIFY_THRESHOLD		0x10
 #define	TCP_ABORT_THRESHOLD		0x11

--- a/usr/src/uts/intel/io/pci/pci_boot.c
+++ b/usr/src/uts/intel/io/pci/pci_boot.c
@@ -1259,6 +1259,7 @@ fix_ppb_res(uchar_t secbus, boolean_t prog_sub)
 	 */
 	uint64_t avail = get_per_bridge_avail(bus);
 
+	mem.size = 0;
 	if (avail > 0) {
 		/* Try 32MiB first, then adjust down until it fits */
 		for (uint_t i = 32; i > 0; i >>= 1) {


### PR DESCRIPTION
This change addressed issue [14744](https://www.illumos.org/issues/14744) the socket option TCP_INFO has been added to OS and to LX brand. 
Other systems like OpenBSD and FreeBSD use the same structure for tcp_info as Linux but their implementations only setups some of the values, leaving the rest as 0s, and they also add their own extensions to the tcp_info struct.
In this implementation I try to map the fields required by some applications like described in [OS-4525](https://smartos.org/bugview/OS-4525). I have doubts if the field mappings  between illumos and Linux are correct, so would like some guidance on that. 
On the other hand the LX changes the tcpi_state should be mapped to and actual Linux tcp_state but at this point lx apps are able to use TCP_INFO.

 

[OS-4525]: https://mnx.atlassian.net/browse/OS-4525?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ