### PR TITLE
14744 Add TCP_INFO option

### DIFF
--- a/usr/src/man/man3head/tcp.h.3head
+++ b/usr/src/man/man3head/tcp.h.3head
@@ -68,9 +68,22 @@ Avoid coalescing of small segments.
 
 .sp
 .LP
+\fB\fBTCP_INFO\fR\fR
+.ad
+.RS 15n
+Information about a socket's underlying TCP session may be retrieved by passing the read-only option
+TCP_INFO to getsockopt(2). It accepts a single argu ment: a pointer to an instance of struct tcp_info.
+.RE
+
+.sp
+.LP
 The macro is defined in the header. The implementation need not allow the value
 of the option to be set with \fBsetsockopt()\fR or retrieved with
 \fBgetsockopt()\fR.
+.sp
+.LP
+
+
 .SH ATTRIBUTES
 .sp
 .LP

--- a/usr/src/uts/common/brand/lx/syscall/lx_socket.c
+++ b/usr/src/uts/common/brand/lx/syscall/lx_socket.c
@@ -24,6 +24,7 @@
  * Use is subject to license terms.
  * Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
  * Copyright 2022 Joyent, Inc.
+ * Copyright 2023 Carlos Neira <cneirabustos@gmail.com>
  */
 
 #include <sys/errno.h>
@@ -2825,7 +2826,7 @@ static const lx_sockopt_map_t ltos_tcp_sockopts[LX_TCP_NOTSENT_LOWAT + 1] = {
 	{ TCP_LINGER2, sizeof (int) },		/* TCP_LINGER2		*/
 	{ OPTNOTSUP, 0 },			/* TCP_DEFER_ACCEPT - in code */
 	{ OPTNOTSUP, 0 },			/* TCP_WINDOW_CLAMP - in code */
-	{ OPTNOTSUP, 0 },			/* TCP_INFO		*/
+	{ TCP_INFO, sizeof (tcp_info_t) },	/* TCP_INFO		*/
 	{ TCP_QUICKACK, sizeof (int) },		/* TCP_QUICKACK		*/
 	{ TCP_CONGESTION, CC_ALGO_NAME_MAX },	/* TCP_CONGESTION	*/
 	{ OPTNOTSUP, 0 },			/* TCP_MD5SIG		*/
@@ -3865,6 +3866,7 @@ lx_getsockopt_tcp(sonode_t *so, int optname, void *optval, socklen_t *optlen)
 	lx_proto_opts_t sockopts_tbl = PROTO_SOCKOPTS(ltos_tcp_sockopts);
 
 	switch (optname) {
+
 	case LX_TCP_WINDOW_CLAMP:
 		/*
 		 * We do not support these options but some apps rely on them.

--- a/usr/src/uts/common/netinet/tcp.h
+++ b/usr/src/uts/common/netinet/tcp.h
@@ -23,6 +23,7 @@
  * Copyright (c) 1991, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2011 Nexenta Systems, Inc. All rights reserved.
  * Copyright 2022 Oxide Computer Company
+ * Copyright 2023 Carlos Neira <cneirabustos@gmail.com>
  */
 
 /*
@@ -75,6 +76,9 @@ struct tcphdr {
 	uint16_t	th_urp;		/* urgent pointer */
 };
 
+
+
+
 #define	TCPOPT_EOL	0
 #define	TCPOPT_NOP	1
 #define	TCPOPT_MAXSEG	2
@@ -88,6 +92,8 @@ struct tcphdr {
  * With an IP MTU of 576, this is 536.
  */
 #define	TCP_MSS	536
+
+
 
 /*
  * Options for use with [gs]etsockopt at the TCP level.
@@ -109,6 +115,44 @@ struct tcphdr {
 #define	TCP_KEEPALIVE	0x8	/* set keepalive timer */
 #endif
 
+#ifndef TCP_INFO
+#define	TCP_INFO	0x09	/* retrieve tcp_info structure */
+#endif
+	typedef struct tcp_info {
+		uint8_t	tcpi_state;
+		uint8_t	tcpi_ca_state;
+		uint8_t	tcpi_retransmits;
+		uint8_t	tcpi_probes;
+		uint8_t	tcpi_backoff;
+		uint8_t	tcpi_options;
+		uint8_t	tcpi_snd_wscale : 4, tcpi_rcv_wscale : 4;
+		uint32_t	tcpi_rto;
+		uint32_t	tcpi_ato;
+		uint32_t	tcpi_snd_mss;
+		uint32_t	tcpi_rcv_mss;
+		uint32_t	tcpi_unacked;
+		uint32_t	tcpi_sacked;
+		uint32_t	tcpi_lost;
+		uint32_t	tcpi_retrans;
+		uint32_t	tcpi_fackets;
+		/* Times. */
+		uint32_t	tcpi_last_data_sent;
+		uint32_t	tcpi_last_ack_sent;
+		uint32_t	tcpi_last_data_recv;
+		uint32_t	tcpi_last_ack_recv;
+		/* Metrics. */
+		uint32_t	tcpi_pmtu;
+		uint32_t	tcpi_rcv_ssthresh;
+		uint32_t	tcpi_rtt;
+		uint32_t	tcpi_rttvar;
+		uint32_t	tcpi_snd_ssthresh;
+		uint32_t	tcpi_snd_cwnd;
+		uint32_t	tcpi_advmss;
+		uint32_t	tcpi_reordering;
+		uint32_t	tcpi_rcv_rtt;
+		uint32_t	tcpi_rcv_space;
+		uint32_t	tcpi_total_retrans;
+	} tcp_info_t;
 
 #define	TCP_NOTIFY_THRESHOLD		0x10
 #define	TCP_ABORT_THRESHOLD		0x11


### PR DESCRIPTION
This PR addresses [14744](https://www.illumos.org/issues/14744).
Other systems like OpenBSD and FreeBSD use the same structure for tcp_info as Linux but their implementations only setups some of the values, leaving the rest as 0s, and they also add their own extensions to the tcp_info struct.
In this implementation we don't add our own extensions and as the other systems we use the same tcp_info struct as Linux.
For the OS there is no problem but I have doubts on the mapping of the fields between illumos and Linux tcp counters.
On the LX brand zones there is a problem as illumos tcp states are defined different than Linux, but applications according to 
[OS-4525](https://smartos.org/bugview/OS-4525) are not using the state field at this point, but lx applications at least should be able to use the TCP_INFO option at this point.
I would like some guidance on more changes or how to address the mapping between tcp counters or if just enough to lie the  the lx brand about tcp states or we just need to do some more work and map accordingly those values. 

[OS-4525]: https://mnx.atlassian.net/browse/OS-4525?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

mail_msg 
```
==== Nightly distributed build started:   Fri Nov 17 23:35:32 UTC 2023 ====
==== Nightly distributed build completed: Fri Nov 17 23:46:02 UTC 2023 ====

==== Total build time ====

real    0:10:29

==== Build environment ====

/usr/bin/uname
SunOS a234ec28-2af2-4640-890b-185210f8fc7b 5.11 joyent_20231117T132049Z i86pc i386 i86pc

/home/build/smartos-live/projects/illumos/usr/src/tools/proto/root_i386-nd/opt/onbld/bin/i386/dmake
dmake: illumos make
number of concurrent jobs = 6

cw version 9.0
primary: /home/build/smartos-live/proto.strap/usr/gcc/10/bin/gcc
gcc (GCC) 10.4.0
Copyright (C) 2020 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

shadow: /home/build/smartos-live/projects/illumos/usr/src/tools/proto/root_i386-nd/opt/onbld/bin/i386/smatch
0.6.1-rc1-il-7

/opt/local/java/openjdk11/bin/javac
openjdk full version "11.0.16.1-internal+0-adhoc.root.jdk11u-jdk-11.0.16.1-ga"

/usr/bin/openssl
OpenSSL 3.0.12 24 Oct 2023 (Library: OpenSSL 3.0.12 24 Oct 2023)

/usr/ccs/bin/ld
ld: Software Generation Utilities - Solaris Link Editors: 5.11-1.1790 (illumos)

Build project:  default
Build taskid:   167

==== Nightly argument issues ====

Warning: the N option (do not run protocmp) is set; it probably shouldn't be


==== Build version ====

joyent_20231117T132049Z

==== Bootstrap build errors ====


==== Tools build errors ====


==== Build errors (non-DEBUG) ====


==== Build warnings (non-DEBUG) ====


==== Elapsed build time (non-DEBUG) ====

real     8:28.9
user    17:15.5
sys      9:38.7

==== cstyle/hdrchk errors ====


==== Find core files ====
```

