### PR TITLE
16087 import OpenZFS 15571 check dnode and its data for dirtiness (early pull)

### DIFF
--- a/usr/src/uts/common/fs/zfs/dmu.c
+++ b/usr/src/uts/common/fs/zfs/dmu.c
@@ -2440,7 +2440,8 @@ dmu_object_wait_synced(objset_t *os, uint64_t object)
 	}
 
 	for (i = 0; i < TXG_SIZE; i++) {
-		if (list_link_active(&dn->dn_dirty_link[i])) {
+		if (list_link_active(&dn->dn_dirty_link[i]) ||
+		    !list_is_empty(&dn->dn_dirty_records[i])) {
 			break;
 		}
 	}


### PR DESCRIPTION
This has been tested, see https://illumos.org/issues/16087