### PR TITLE
OS-8502 Remove unused symbols from libsmartsshd

### DIFF
--- a/usr/src/lib/libsmartsshd/common/mapfile-vers
+++ b/usr/src/lib/libsmartsshd/common/mapfile-vers
@@ -38,7 +38,7 @@
 
 $mapfile_version 2
 
-SYMBOL_VERSION SUNWprivate_1.2 {
+SYMBOL_VERSION SUNWprivate_1.1 {
     global:
 	sshd_user_key_allowed;
     local:

--- a/usr/src/lib/libsmartsshd/common/mapfile-vers
+++ b/usr/src/lib/libsmartsshd/common/mapfile-vers
@@ -19,6 +19,7 @@
 # CDDL HEADER END
 #
 # Copyright 2016 Joyent, Inc.
+# Copyright 2023 MNX Cloud, Inc.
 #
 
 #
@@ -37,11 +38,8 @@
 
 $mapfile_version 2
 
-SYMBOL_VERSION SUNWprivate_1.1 {
+SYMBOL_VERSION SUNWprivate_1.2 {
     global:
-	sshd_user_rsa_key_allowed;
-	sshd_user_dsa_key_allowed;
-	sshd_user_ecdsa_key_allowed;
 	sshd_user_key_allowed;
     local:
 	*;

--- a/usr/src/lib/libsmartsshd/common/sshd-plugin.c
+++ b/usr/src/lib/libsmartsshd/common/sshd-plugin.c
@@ -21,6 +21,7 @@
 
 /*
  * Copyright 2016 Joyent, Inc.
+ * Copyright 2023 MNX Cloud, Inc.
  */
 
 #include <alloca.h>
@@ -165,27 +166,6 @@ sshd_user_key_allowed(struct passwd *pw, const char *type,
 	if (tohexstr(md5buf, sizeof (md5buf), hex, sizeof (hex)) != 0)
 		return (0);
 	return (sshd_allowed_in_capi(pw, hex));
-}
-
-/* ARGSUSED */
-int
-sshd_user_rsa_key_allowed(struct passwd *pw, RSA *key, const char *fp)
-{
-	return (sshd_allowed_in_capi(pw, fp));
-}
-
-/* ARGSUSED */
-int
-sshd_user_dsa_key_allowed(struct passwd *pw, DSA *key, const char *fp)
-{
-	return (sshd_allowed_in_capi(pw, fp));
-}
-
-/* ARGSUSED */
-int
-sshd_user_ecdsa_key_allowed(struct passwd *pw, DSA *key, const char *fp)
-{
-	return (sshd_allowed_in_capi(pw, fp));
 }
 
 #ifdef __cplusplus


### PR DESCRIPTION
Remove the per-key-type symbols for checking SSH keys as only the `sshd_user_key_allowed` function is used to check keys now. This PR is related to TritonDataCenter/illumos-extra/pull/101 but it is not essential, just cleanup.

See [OS-8502](https://mnx.atlassian.net/browse/OS-8502?focusedCommentId=123016) for testing notes.

[OS-8502]: https://mnx.atlassian.net/browse/OS-8502?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ