### PR TITLE
OS-8564 SmartOS is missing links for zfstest

### DIFF
--- a/usr/src/test/zfs-tests/cmd/scripts/zfstest.ksh
+++ b/usr/src/test/zfs-tests/cmd/scripts/zfstest.ksh
@@ -17,7 +17,7 @@
 # Copyright 2019 Joyent, Inc.
 # Copyright 2021 Tintri by DDN, Inc. All rights reserved.
 # Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
-# Copyright 2022 MNX Cloud, Inc.
+# Copyright 2024 MNX Cloud, Inc.
 #
 
 export PATH="/usr/bin"
@@ -136,10 +136,10 @@ function constrain_path
 	# SmartOS does not ship some required commands by default.
 	# Link to them in the package manager's namespace.
 	pkgsrc_bin=/opt/tools/bin
-	pkgsrc_packages="sudo truncate python base64 shuf sha256sum"
+	pkgsrc_packages="fio uuidgen md5sum sudo truncate python base64 shuf sha256sum"
 	for pkg in $pkgsrc_packages; do
 		if [[ ! -x $PATHDIR/$pkg ]]; then
-			rm $PATHDIR/$pkg &&
+			rm -f $PATHDIR/$pkg &&
 			    ln -s $pkgsrc_bin/$pkg $PATHDIR/$pkg ||
 			    fail "Couldn't link $pkg"
 		fi


### PR DESCRIPTION
zfstest needs to create few more links while running in SmartOS system