### PR TITLE
OS-8565 zut is not loaded for zfs tests

### DIFF
--- a/usr/src/test/smartos-test/smartos-test.sh
+++ b/usr/src/test/smartos-test/smartos-test.sh
@@ -317,8 +317,11 @@ function zfs_test_check {
 	echo "export DISKS" >> $zprofile
     fi
 
+    # Allow access to ZFS unit tests driver.
+    add_drv zut
     # OKAY, now we can run it!
     log_test zfstest su - ztest -c /opt/zfs-tests/bin/zfstest
+    rem_drv zut
 }
 
 function nvme_test_check {


### PR DESCRIPTION
zfstests need to access /dev/zut.

Once present:
ztest@smartos:~$ /opt/zfs-tests/bin/zfstest -T casenorm                         
Test: /opt/zfs-tests/tests/functional/casenorm/setup (run as root) [00:00] [PASS]
Test: /opt/zfs-tests/tests/functional/casenorm/case_all_values (run as root) [00:01] [PASS]
Test: /opt/zfs-tests/tests/functional/casenorm/norm_all_values (run as root) [00:02] [PASS]
Test: /opt/zfs-tests/tests/functional/casenorm/sensitive_none_lookup (run as root) [00:01] [PASS]
Test: /opt/zfs-tests/tests/functional/casenorm/sensitive_none_delete (run as root) [00:00] [PASS]
Test: /opt/zfs-tests/tests/functional/casenorm/sensitive_formd_lookup (run as root) [00:00] [PASS]
Test: /opt/zfs-tests/tests/functional/casenorm/sensitive_formd_delete (run as root) [00:01] [PASS]
Test: /opt/zfs-tests/tests/functional/casenorm/insensitive_none_lookup (run as root) [00:00] [PASS]
Test: /opt/zfs-tests/tests/functional/casenorm/insensitive_none_delete (run as root) [00:01] [PASS]
Test: /opt/zfs-tests/tests/functional/casenorm/insensitive_formd_lookup (run as root) [00:00] [PASS]
Test: /opt/zfs-tests/tests/functional/casenorm/insensitive_formd_delete (run as root) [00:02] [PASS]
Test: /opt/zfs-tests/tests/functional/casenorm/mixed_none_lookup (run as root) [00:01] [PASS]
Test: /opt/zfs-tests/tests/functional/casenorm/mixed_none_lookup_ci (run as root) [00:00] [PASS]
Test: /opt/zfs-tests/tests/functional/casenorm/mixed_none_delete (run as root) [00:00] [PASS]
Test: /opt/zfs-tests/tests/functional/casenorm/mixed_formd_lookup (run as root) [00:00] [PASS]
Test: /opt/zfs-tests/tests/functional/casenorm/mixed_formd_lookup_ci (run as root) [00:00] [PASS]
Test: /opt/zfs-tests/tests/functional/casenorm/mixed_formd_delete (run as root) [00:01] [PASS]
Test: /opt/zfs-tests/tests/functional/casenorm/cleanup (run as root) [00:00] [PASS]

Results Summary
PASS      18

Running Time:   00:00:20
Percent passed: 100.0%
Log directory:  /var/tmp/test_results/20240809T132049
ztest@smartos:~$