### PR TITLE
OS-8572 Remove svr4pkg_test from SmartOS tests

### DIFF
--- a/usr/src/test/util-tests/runfiles/default.run
+++ b/usr/src/test/util-tests/runfiles/default.run
@@ -110,8 +110,5 @@ tests = ['sed_addr', 'multi_test']
 [/opt/util-tests/tests/pcieadm-priv]
 user = root
 
-[/opt/util-tests/tests/svr4pkg_test]
-user = root
-
 [/opt/util-tests/tests/ar/artest]
 [/opt/util-tests/tests/cpio/cpio_test]


### PR DESCRIPTION
Just removing it from `default.run`, unless you think it's worth killing with fire.

ALSO OF NOTE:  The bug report mentions that maybe we should not ship SVR4-adjacent items.  That's a harder test and beyond the scope of this bug.  It WOULD shrink the PI a bit if we did THAT, but that's not a problem for here.