### PR TITLE
OS-8588 lx_brand: argument 2 of type 'const struct timeval[2]' with m…

### DIFF
--- a/usr/src/lib/brand/lx/lx_brand/sys/lx_syscall.h
+++ b/usr/src/lib/brand/lx/lx_brand/sys/lx_syscall.h
@@ -174,7 +174,7 @@ extern long lx_timerfd_create(int, int);
 extern long lx_timerfd_settime(int, int,
     const struct itimerspec *, struct itimerspec *);
 extern long lx_timerfd_gettime(int, struct itimerspec *);
-extern long lx_utimes(const char *, const struct timeval *);
+extern long lx_utimes(const char *, const struct timeval [2]);
 
 #endif	/* !defined(_ASM) */
 


### PR DESCRIPTION
Fix declaration to match definition. Build is ok.