### PR TITLE
OS-8606 uts should use KPRINTFLIKE

### DIFF
--- a/usr/src/uts/common/ipp/ippctl.c
+++ b/usr/src/uts/common/ipp/ippctl.c
@@ -73,9 +73,8 @@ static	uint64_t	ippctl_debug_flags =
 
 static kmutex_t	debug_mutex[1];
 
-/*PRINTFLIKE3*/
 static void	ippctl_debug(uint64_t, char *, char *, ...)
-	__PRINTFLIKE(3);
+	__KPRINTFLIKE(3);
 
 #define	DBG0(_type, _fmt)		    			\
 	ippctl_debug((_type), __FN__, (_fmt));

--- a/usr/src/uts/i86pc/dboot/dboot_printf.h
+++ b/usr/src/uts/i86pc/dboot/dboot_printf.h
@@ -38,7 +38,7 @@ extern "C" {
  *        %%, %b, %c, %d, %o, %p, %s, %x and size specifiers l, ll, j, z
  */
 extern void dboot_printf(char *fmt, ...)
-    __PRINTFLIKE(1);
+    __KPRINTFLIKE(1);
 
 /*
  * Primitive version of panic, prints a message, waits for a keystroke,

--- a/usr/src/uts/intel/io/dktp/hba/ghd/ghd_debug.h
+++ b/usr/src/uts/intel/io/dktp/hba/ghd/ghd_debug.h
@@ -33,8 +33,7 @@ extern "C" {
 
 #include <sys/varargs.h>
 
-/*PRINTFLIKE1*/
-extern void ghd_err(const char *fmt, ...) __PRINTFLIKE(1);
+extern void ghd_err(const char *fmt, ...) __KPRINTFLIKE(1);
 extern ulong_t ghd_debug_flags;
 
 #define	GDBG_FLAG_ERROR		0x0001

--- a/usr/src/uts/intel/sys/promif.h
+++ b/usr/src/uts/intel/sys/promif.h
@@ -171,19 +171,17 @@ extern	int		prom_seek(int fd, unsigned long long offset);
 
 extern	void		prom_writestr(const char *buf, size_t bufsize);
 
-/*PRINTFLIKE1*/
 extern	void		prom_printf(const char *fmt, ...)
-	__PRINTFLIKE(1);
+	__KPRINTFLIKE(1);
 #pragma	rarely_called(prom_printf)
 extern	void		prom_vprintf(const char *fmt, __va_list adx)
-	__VPRINTFLIKE(1);
+	__KVPRINTFLIKE(1);
 #pragma	rarely_called(prom_vprintf)
 
-/*PRINTFLIKE2*/
 extern	char		*prom_sprintf(char *s, const char *fmt, ...)
-	__PRINTFLIKE(2);
+	__KPRINTFLIKE(2);
 extern	char		*prom_vsprintf(char *s, const char *fmt, __va_list adx)
-	__VPRINTFLIKE(2);
+	__KVPRINTFLIKE(2);
 
 /*
  * promif tree searching routines ... OBP and IEEE 1275-1994.

--- a/usr/src/uts/sun/sys/dada/adapters/ghd/ghd_debug.h
+++ b/usr/src/uts/sun/sys/dada/adapters/ghd/ghd_debug.h
@@ -27,16 +27,13 @@
 #ifndef _GHD_DEBUG_H
 #define	_GHD_DEBUG_H
 
-#pragma ident	"%Z%%M%	%I%	%E% SMI"
-
 #ifdef	__cplusplus
 extern "C" {
 #endif
 
 #include <sys/varargs.h>
 
-/*PRINTFLIKE1*/
-extern void ghd_err(const char *fmt, ...) __PRINTFLIKE(1);
+extern void ghd_err(const char *fmt, ...) __KPRINTFLIKE(1);
 extern	ulong_t	ghd_debug_flags;
 
 #define	GDBG_FLAG_ERROR		0x0001

--- a/usr/src/uts/sun/sys/promif.h
+++ b/usr/src/uts/sun/sys/promif.h
@@ -266,20 +266,18 @@ extern	int		prom_seek(int fd, u_longlong_t offset);
 extern	void		prom_writestr(const char *buf, size_t bufsize);
 extern	void		prom_pnode_to_pathname(pnode_t, char *);
 
-/*PRINTFLIKE1*/
 extern	void		prom_printf(const char *fmt, ...)
-	__PRINTFLIKE(1);
+	__KPRINTFLIKE(1);
 #pragma rarely_called(prom_printf)
 
 extern	void		prom_vprintf(const char *fmt, __va_list adx)
-	__VPRINTFLIKE(1);
+	__KVPRINTFLIKE(1);
 #pragma rarely_called(prom_vprintf)
 
-/*PRINTFLIKE2*/
 extern	char		*prom_sprintf(char *s, const char *fmt, ...)
-	__PRINTFLIKE(2);
+	__KPRINTFLIKE(2);
 extern	char		*prom_vsprintf(char *s, const char *fmt, __va_list adx)
-	__VPRINTFLIKE(2);
+	__KVPRINTFLIKE(2);
 
 #define	PROM_WALK_CONTINUE	0	/* keep walking to next node */
 #define	PROM_WALK_TERMINATE	1	/* abort walk now */


### PR DESCRIPTION
in uts tree, replace __PRINTFLIKE with __KPRINTFLIKE. This is now possible because we have updated gcc 10. I guess, the actual integration will have to wait till we stop using gcc 7 as shadow.

